### PR TITLE
fix(package.json): make babel-runtime a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "url": "https://github.com/jcoreio/promisify-child-process/issues"
   },
   "homepage": "https://github.com/jcoreio/promisify-child-process#readme",
+  "dependencies": {
+    "babel-runtime": "^6.23.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "^6.0.2",
     "@commitlint/config-conventional": "^6.0.2",
@@ -66,7 +69,6 @@
     "babel-preset-flow": "^6.23.0",
     "babel-preset-stage-1": "^6.22.0",
     "babel-register": "^6.23.0",
-    "babel-runtime": "^6.23.0",
     "chai": "^4.1.2",
     "codecov": "^3.0.0",
     "copy": "^0.3.0",


### PR DESCRIPTION
`babel-runtime` was listed as a development dependency but it is required at runtime as well. This
change simply moves the requirement to the `dependencies` section of `package.json`.

Fixes #10