### PR TITLE
fix: make swap and fork options extend promisify option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,10 @@ interface PromisifyChildProcessOptions {
   encoding?: string;
 }
 
+type PromisifySpawnOptions = SpawnOptions & PromisifyChildProcessOptions;
+
+type PromisifyForkOptions = ForkOptions & PromisifyChildProcessOptions;
+
 export function promisifyChildProcess(
   child: ChildProcess,
   options?: PromisifyChildProcessOptions
@@ -32,21 +36,21 @@ export function promisifyChildProcess(
 export function spawn(
   command: string,
   args: Array<string>,
-  options?: SpawnOptions
+  options?: PromisifySpawnOptions
 ): ChildProcessPromise;
 export function spawn(
   command: string,
-  options?: SpawnOptions
+  options?: PromisifySpawnOptions
 ): ChildProcessPromise;
 
 export function fork(
   module: string,
   args: Array<string>,
-  options?: ForkOptions
+  options?: PromisifyForkOptions
 ): ChildProcessPromise;
 export function fork(
   module: string,
-  options?: ForkOptions
+  options?: PromisifyForkOptions
 ): ChildProcessPromise;
 
 export function exec(


### PR DESCRIPTION
`index.d.ts` uses the type of `SpawnOptions` and `ForkOptions` from `child_process`, it fails to compile with typescript due to not existing `encoding` property in option declaration.